### PR TITLE
make explicit mention of expected outcomes

### DIFF
--- a/client/static/corsclient.html
+++ b/client/static/corsclient.html
@@ -3,6 +3,7 @@
  <head>
   <title>test-cors.org</title>
   <link href="css/bootstrap-2.3.1.min.css" rel="stylesheet" media="screen">
+  <link rel="stylesheet" href="./css/corsclient.css" />
  </head>
  <body>
 
@@ -61,9 +62,10 @@
     </div>
 
     <div class="control-group">
-    <div class="controls">
-      <button class="btn btn-large btn-primary" type="button" id="btnSendRequest">Send Request</button>
-    </div></div>
+      <div class="controls">
+        <button class="btn btn-large btn-primary" type="button" id="btnSendRequest">Send Request</button>
+      </div>
+    </div>
 
     </form>
   </div>

--- a/client/static/css/corsclient.css
+++ b/client/static/css/corsclient.css
@@ -42,3 +42,11 @@ td {
 .headers {
   margin: 0 0 0 0;
 }
+
+.inline-code {
+  padding: 2px 4px;
+  color: black;
+  white-space: nowrap;
+  background-color: #f7f7f9;
+  border: 1px solid #e1e1e8;
+}

--- a/client/static/js/corsclient.js
+++ b/client/static/js/corsclient.js
@@ -541,6 +541,9 @@ var sendRequest = function(controller, url) {
   // Link to this test.
   logger.log('<a href="#" onclick="javascript:prompt(\'Here\\\'s a link to this test\', \'' + htmlEscape(window.location.href) + '\');return false;">Link to this test</a><br>');
 
+  // point out what users should expect to encounter when testing a server that supports CORS
+  logger.log('<p>Note: CORS enabled remote servers return <span class="inline-code">XHR status: 200</span></p>');
+
   // Create the XHR object and make the request.
   var httpMethod = controller.getValue('client_method');
   var serverUrl = getServerUrl(controller);


### PR DESCRIPTION
i experienced the same confusion as @trinzia when using this _really_ neat tool, so i added a note to the log to explain to users what they should look for when running their own tests.

> Note: CORS enabled remote servers return `XHR status: 200`

resolves #11