### PR TITLE
Position the popovers above their inputs

### DIFF
--- a/client/static/js/corsclient.js
+++ b/client/static/js/corsclient.js
@@ -621,9 +621,9 @@ $(function() {
   // Set up the help menus.
   var help_divs = $('.control-group').filter('div[id]').each(function() {
     var id = $(this).attr('id');
-    var placement = 'left';
+    var placement = 'top';
     if (id.indexOf('server_') == 0) {
-      placement = 'right';
+      placement = 'top';
     }
     $(this).popover({
       placement: placement,


### PR DESCRIPTION
This is as opposed to positioning the popovers on the sides of their inputs. That had resulted in the text within the popovers sometimes being positioned outside of the viewport (as shown below).

---

Here's a set of before-and-after screenshots (taken in Google Chrome with viewport dimensions of 1000px by 1000px):

### Before

![image](https://user-images.githubusercontent.com/7143133/32825289-4a088914-c999-11e7-92f9-9818ace69433.png)

### After (i.e. with this proposal in effect)

![image](https://user-images.githubusercontent.com/7143133/32825296-51e058c4-c999-11e7-9d5d-2e53cc88c76d.png)
