### PR TITLE
Update popover title to match input label

### DIFF
--- a/client/static/corsclient.html
+++ b/client/static/corsclient.html
@@ -54,7 +54,7 @@
       </div>
     </div>
 
-    <div class="control-group" id="client_postdata_div" title="Help: Content?" data-content="Data that the client will send in the body of the request.">
+    <div class="control-group" id="client_postdata_div" title="Help: Request Content" data-content="Data that the client will send in the body of the request.">
       <label class="control-label" for="client_postdata">Request Content</label>
       <div class="controls">
         <textarea id="client_postdata" class="span2" rows="4"></textarea>


### PR DESCRIPTION
The title of every other popover on the page matches the label of its associated input. Now, this one does, too.

---

Here's a set of screenshots showing the before-and-after appearance of the affected popover:

### Before

![image](https://user-images.githubusercontent.com/7143133/32825793-0a6846e4-c99b-11e7-927b-7a24dff8f42f.png)

### After (i.e. with this proposal in effect)

![image](https://user-images.githubusercontent.com/7143133/32825796-0d10ac88-c99b-11e7-8730-788f99d20729.png)
